### PR TITLE
Update CPMS disable cronjob to run every 15m

### DIFF
--- a/deploy/osd-14634-disable-cpms/10-osd-disable-cpms.CronJob.yaml
+++ b/deploy/osd-14634-disable-cpms/10-osd-disable-cpms.CronJob.yaml
@@ -7,7 +7,7 @@ spec:
   failedJobsHistoryLimit: 3
   successfulJobsHistoryLimit: 1
   concurrencyPolicy: Replace
-  schedule: "0 */1 * * *"
+  schedule: "*/15 * * * *"
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 180

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -19998,7 +19998,7 @@ objects:
         failedJobsHistoryLimit: 3
         successfulJobsHistoryLimit: 1
         concurrencyPolicy: Replace
-        schedule: 0 */1 * * *
+        schedule: '*/15 * * * *'
         jobTemplate:
           spec:
             ttlSecondsAfterFinished: 180

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -19998,7 +19998,7 @@ objects:
         failedJobsHistoryLimit: 3
         successfulJobsHistoryLimit: 1
         concurrencyPolicy: Replace
-        schedule: 0 */1 * * *
+        schedule: '*/15 * * * *'
         jobTemplate:
           spec:
             ttlSecondsAfterFinished: 180

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -19998,7 +19998,7 @@ objects:
         failedJobsHistoryLimit: 3
         successfulJobsHistoryLimit: 1
         concurrencyPolicy: Replace
-        schedule: 0 */1 * * *
+        schedule: '*/15 * * * *'
         jobTemplate:
           spec:
             ttlSecondsAfterFinished: 180


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Updates disable CPMS cronjob to run every 15m instead of 1h to beat CloudIngressOperator's publishing strategy update on newly-installed clusters in order to not provision and orphan an extra control-plane node.

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-14634_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
